### PR TITLE
fix: Add proper CLI entry points for ketu command

### DIFF
--- a/ketu/__main__.py
+++ b/ketu/__main__.py
@@ -1,0 +1,9 @@
+"""Entry point for running Ketu as a module.
+
+This allows running Ketu with: python -m ketu
+"""
+
+from .display import main
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ Repository = "https://github.com/alkimya/ketu"
 Issues = "https://github.com/alkimya/ketu/issues"
 
 [project.scripts]
-ketu = "ketu.ketu:main"
+ketu = "ketu.display:main"
 
 [tool.setuptools]
 packages = ["ketu"]


### PR DESCRIPTION
- Add ketu/__main__.py to enable 'python -m ketu'
- Fix pyproject.toml console script to point to ketu.display:main
- Now supports three ways to run:
  1. ketu (after pip install)
  2. python -m ketu
  3. python -m ketu.display