### PR TITLE
style: Increase legend title font sizes for better visibility

### DIFF
--- a/ketu/chart.py
+++ b/ketu/chart.py
@@ -525,7 +525,7 @@ def _draw_legend_and_table(fig, ax, jd: float, planet_positions: dict,
         ax.text(
             legend_x, legend_y_start, "Planets",
             transform=ax.transAxes,
-            fontsize=12, fontweight='bold',
+            fontsize=14, fontweight='bold',
             ha='left', va='top'
         )
 
@@ -592,7 +592,7 @@ def _draw_legend_and_table(fig, ax, jd: float, planet_positions: dict,
         ax.text(
             legend_x, table_y_start, "Aspects",
             transform=ax.transAxes,
-            fontsize=12, fontweight='bold',
+            fontsize=14, fontweight='bold',
             ha='left', va='top'
         )
 


### PR DESCRIPTION
Increased font size of both legend titles from 12 to 14:
- Planets title: 12 → 14
- Aspects title: 12 → 14

This improves readability and ensures both titles have equal prominence.